### PR TITLE
Define a default main component for the HTML settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Now, there are a few options you can change in order to customize the way the HT
     strict: true,
     cloak: true,
     useBody: true,
-    mainComponent: null,
+    mainComponent: 'main',
   }
 }
 ```

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -51,7 +51,7 @@ class ProjextAngularJSPlugin {
       strict: true,
       cloak: true,
       useBody: true,
-      mainComponent: null,
+      mainComponent: 'main',
     };
     /**
      * The name of the loader the plugin adds to the Webpack configuration.

--- a/tests/plugin.test.js
+++ b/tests/plugin.test.js
@@ -410,7 +410,7 @@ describe('plugin:projextAngularJS/main', () => {
     const expectedSettings = {
       title: currentSettings.title,
       bodyAttributes: `ng-app="${normalizedTargetName}" ng-strict-di ng-cloak`,
-      bodyContents: '',
+      bodyContents: '<main></main>',
     };
     // When
     sut = new ProjextAngularJSPlugin();
@@ -462,14 +462,13 @@ describe('plugin:projextAngularJS/main', () => {
       get: jest.fn(() => events),
     };
     const targetName = 'my-target';
-    const mainComponent = 'root-container';
     const frameworkOptions = {
       title: 'My App',
       appName: 'myCustomApp',
       strict: false,
       cloak: false,
       useBody: false,
-      mainComponent,
+      mainComponent: null,
     };
     const target = {
       name: targetName,
@@ -487,12 +486,11 @@ describe('plugin:projextAngularJS/main', () => {
     let sut = null;
     let reducer = null;
     let result = null;
-    const expectedMainComponent = `<${mainComponent}></${mainComponent}>`;
     const expectedSettings = {
       title: frameworkOptions.title,
       bodyAttributes: '',
       bodyContents: `
-        <div id="app" ng-app="${frameworkOptions.appName}">${expectedMainComponent}</div>
+        <div id="app" ng-app="${frameworkOptions.appName}"></div>
       `.trim(),
     };
     // When


### PR DESCRIPTION
### What does this PR do?

I started a sample project for AngularJS without configuration and without an HTML... and then I realized that without a configuration file I can't define a main component and start pushing things for y app... so I defined the default main component as `main`.

Now you can start coding your AngularJS project without HTML and configuration and worry for those things later.

### How should it be tested manually?

1. Create a project called `my-angularjs-test` (The name is important for the default HTML).
2. Install `projext`, `projext-plugin-webpack` and `projext-plugin-webpack-angularjs`.
3. Create a `src/index.js` file with the following code:

```js
import angular from 'angular';

angular.module('myAngularjsTest', [])
.component('main', {
  template: 'Hello world!',
});
```

And run it! (`projext run`), you should see the `Hello world` on the browser.

**Note:** It's breaking because the setting used to be `null` and now has a value.